### PR TITLE
Update docs and tests for Air Quality fields

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -27,7 +27,6 @@ select = [
   "LOG",    # flake8-logging
   "N804",   # First argument of a class method should be named cls
   "N805",   # First argument of a method should be named self
-  "N806",   # Variable {name} in function should be snake_case
   "N815",   # Variable {name} in class scope should not be mixedCase
   "PERF",   # Perflint
   "PGH",    # pygrep-hooks
@@ -76,6 +75,7 @@ ignore = [
   "ASYNC109", # Async function definition with a `timeout` parameter Use `asyncio.timeout` instead
   "ASYNC110", # Use `asyncio.Event` instead of awaiting `asyncio.sleep` in a `while` loop
   "ASYNC240", # Use an async function for entering the file system
+  "B006",     # Do not use mutable data structures for argument defaults
   "B008",     # Do not perform function call in argument defaults; commonly used in Home Assistant (e.g. cv.* validators)
   "B019",     # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
   "D202",     # No blank lines allowed after function docstring
@@ -85,18 +85,23 @@ ignore = [
   "D407",     # Section name underlining
   "D417",     # Missing argument descriptions in docstring - to allow documenting only non-obvious parameters
   "E501",     # line too long
+  "N806",   # Variable {name} in function should be snake_case
 
   "PLC1901", # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
   "PLR0911", # Too many return statements ({returns} > {max_returns})
   "PLR0912", # Too many branches ({branches} > {max_branches})
   "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
   "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLR0917", # Too many positional arguments
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
   "PLW0108", # Unnecessary lambda wrapping a function call; can often be replaced by the function itself
   "PLW1641", # __eq__ without __hash__
   "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
   "PT011",   # pytest.raises({exception}) is too broad, set the `match` parameter or use a more specific exception
   "PT018",   # Assertion should be broken down into multiple parts
+  "PTH118",   # `os.path.join()` should be replaced by `Path` with `/` operator
+  "PTH120",   # `os.path.dirname()` should be replaced by `Path.parent`
+  "PTH123",   # `open()` should be replaced by `Path.open()`
   "RUF001",  # String contains ambiguous unicode character.
   "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
   "RUF015",  # Prefer next(...) over single element slice

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -4,130 +4,136 @@ target-version = "py312"
 
 [lint]
 select = [
-    "A001", # Variable {name} is shadowing a Python builtin
-    "ASYNC210", # Async functions should not call blocking HTTP methods
-    "ASYNC220", # Async functions should not create subprocesses with blocking methods
-    "ASYNC221", # Async functions should not run processes with blocking methods
-    "ASYNC222", # Async functions should not wait on processes with blocking methods
-    "ASYNC230", # Async functions should not open files with blocking methods like open
-    "ASYNC251", # Async functions should not call time.sleep
-    "B002", # Python does not support the unary prefix increment
-    "B005", # Using .strip() with multi-character strings is misleading
-    "B007", # Loop control variable {name} not used within loop body
-    "B014", # Exception handler with duplicate exception
-    "B015", # Pointless comparison. Did you mean to assign a value? Otherwise, prepend assert or remove it.
-    "B017", # pytest.raises(BaseException) should be considered evil
-    "B018", # Found useless attribute access. Either assign it to a variable or remove it.
-    "B023", # Function definition does not bind loop variable {name}
-    "B026", # Star-arg unpacking after a keyword argument is strongly discouraged
-    "B032", # Possible unintentional type annotation (using :). Did you mean to assign (using =)?
-    "B904", # Use raise from to specify exception cause
-    "B905", # zip() without an explicit strict= parameter
-    "BLE",
-    "C", # complexity
-    "COM818", # Trailing comma on bare tuple prohibited
-    "D", # docstrings
-    "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
-    "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
-    "E", # pycodestyle
-    "F", # pyflakes/autoflake
-    "FLY", # flynt
-    "FURB", # refurb
-    "G", # flake8-logging-format
-    "I", # isort
-    "INP", # flake8-no-pep420
-    "ISC", # flake8-implicit-str-concat
-    "ICN001", # import concentions; {name} should be imported as {asname}
-    "LOG", # flake8-logging
-    "N804", # First argument of a class method should be named cls
-    "N805", # First argument of a method should be named self
-    "N815", # Variable {name} in class scope should not be mixedCase
-    "PERF", # Perflint
-    "PGH", # pygrep-hooks
-    "PIE", # flake8-pie
-    "PL", # pylint
-    "PT", # flake8-pytest-style
-    "PYI", # flake8-pyi
-    "RET", # flake8-return
-    "RSE", # flake8-raise
-    "RUF005", # Consider iterable unpacking instead of concatenation
-    "RUF006", # Store a reference to the return value of asyncio.create_task
-    "RUF010", # Use explicit conversion flag
-    "RUF013", # PEP 484 prohibits implicit Optional
-    "RUF017", # Avoid quadratic list summation
-    "RUF018", # Avoid assignment expressions in assert statements
-    "RUF019", # Unnecessary key check before dictionary access
-    # "RUF100", # Unused `noqa` directive; temporarily every now and then to clean them up
-    "S102", # Use of exec detected
-    "S103", # bad-file-permissions
-    "S108", # hardcoded-temp-file
-    "S306", # suspicious-mktemp-usage
-    "S307", # suspicious-eval-usage
-    "S313", # suspicious-xmlc-element-tree-usage
-    "S314", # suspicious-xml-element-tree-usage
-    "S315", # suspicious-xml-expat-reader-usage
-    "S316", # suspicious-xml-expat-builder-usage
-    "S317", # suspicious-xml-sax-usage
-    "S318", # suspicious-xml-mini-dom-usage
-    "S319", # suspicious-xml-pull-dom-usage
-    "S601", # paramiko-call
-    "S602", # subprocess-popen-with-shell-equals-true
-    "S604", # call-with-shell-equals-true
-    "S608", # hardcoded-sql-expression
-    "S609", # unix-command-wildcard-injection
-    "SIM", # flake8-simplify
-    "SLF", # flake8-self
-    "SLOT", # flake8-slots
-    "T100", # Trace found: {name} used
-    "T20", # flake8-print
-    "TID251", # Banned imports
-    "TRY", # tryceratops
-    "UP", # pyupgrade
-    "W", # pycodestyle
+  "A001",   # Variable {name} is shadowing a Python builtin
+  "ASYNC",  # flake8-async
+  "B",      # flake8-bugbear
+  "BLE",
+  "C",      # complexity
+  "COM818", # Trailing comma on bare tuple prohibited
+  "D",      # docstrings
+  "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
+  "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
+  "DTZ011", # Use datetime.now(tz=).date() instead of date.today()
+  "E",      # pycodestyle
+  "F",      # pyflakes/autoflake
+  "F541",   # f-string without any placeholders
+  "FLY",    # flynt
+  "FURB",   # refurb
+  "G",      # flake8-logging-format
+  "I",      # isort
+  "INP",    # flake8-no-pep420
+  "ISC",    # flake8-implicit-str-concat
+  "ICN001", # import concentions; {name} should be imported as {asname}
+  "LOG",    # flake8-logging
+  "N804",   # First argument of a class method should be named cls
+  "N805",   # First argument of a method should be named self
+  "N806",   # Variable {name} in function should be snake_case
+  "N815",   # Variable {name} in class scope should not be mixedCase
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # pylint
+  "PT",     # flake8-pytest-style
+  "PTH",    # flake8-pathlib
+  "PYI",    # flake8-pyi
+  "RET",    # flake8-return
+  "RSE",    # flake8-raise
+  "RUF",    # Ruff-specific rules (see `ignore` for exclusions)
+  "S107",   # Possible hardcoded password assigned to function default
+  "S102",   # Use of exec detected
+  "S103",   # bad-file-permissions
+  "S108",   # hardcoded-temp-file
+  "S301",   # suspicious-pickle-usage
+  "S306",   # suspicious-mktemp-usage
+  "S307",   # suspicious-eval-usage
+  "S313",   # suspicious-xmlc-element-tree-usage
+  "S314",   # suspicious-xml-element-tree-usage
+  "S315",   # suspicious-xml-expat-reader-usage
+  "S316",   # suspicious-xml-expat-builder-usage
+  "S317",   # suspicious-xml-sax-usage
+  "S318",   # suspicious-xml-mini-dom-usage
+  "S319",   # suspicious-xml-pull-dom-usage
+  "S601",   # paramiko-call
+  "S602",   # subprocess-popen-with-shell-equals-true
+  "S604",   # call-with-shell-equals-true
+  "S608",   # hardcoded-sql-expression
+  "S609",   # unix-command-wildcard-injection
+  "SIM",    # flake8-simplify
+  "SLF",    # flake8-self
+  "SLOT",   # flake8-slots
+  "T100",   # Trace found: {name} used
+  "T20",    # flake8-print
+  "TC",     # flake8-type-checking
+  "TID",    # Tidy imports
+  "TRY",    # tryceratops
+  "UP",     # pyupgrade
+  "UP031",  # Use format specifiers instead of percent format
+  "UP032",  # Use f-string instead of `format` call
+  "W",      # pycodestyle
 ]
 
 ignore = [
-    "D202", # No blank lines allowed after function docstring
-    "D203", # 1 blank line required before class docstring
-    "D213", # Multi-line docstring summary should start at the second line
-    "D406", # Section name should end with a newline
-    "D407", # Section name underlining
-    "E501", # line too long
+  "ASYNC109", # Async function definition with a `timeout` parameter Use `asyncio.timeout` instead
+  "ASYNC110", # Use `asyncio.Event` instead of awaiting `asyncio.sleep` in a `while` loop
+  "ASYNC240", # Use an async function for entering the file system
+  "B008",     # Do not perform function call in argument defaults; commonly used in Home Assistant (e.g. cv.* validators)
+  "B019",     # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
+  "D202",     # No blank lines allowed after function docstring
+  "D203",     # 1 blank line required before class docstring
+  "D213",     # Multi-line docstring summary should start at the second line
+  "D406",     # Section name should end with a newline
+  "D407",     # Section name underlining
+  "D417",     # Missing argument descriptions in docstring - to allow documenting only non-obvious parameters
+  "E501",     # line too long
 
-    "PLC1901", # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
-    "PLR0911", # Too many return statements ({returns} > {max_returns})
-    "PLR0912", # Too many branches ({branches} > {max_branches})
-    "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
-    "PLR0915", # Too many statements ({statements} > {max_statements})
-    "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
-    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
-    "PT011", # pytest.raises({exception}) is too broad, set the `match` parameter or use a more specific exception
-    "PT018", # Assertion should be broken down into multiple parts
-    "RUF001", # String contains ambiguous unicode character.
-    "RUF002", # Docstring contains ambiguous unicode character.
-    "RUF003", # Comment contains ambiguous unicode character.
-    "RUF015", # Prefer next(...) over single element slice
-    "SIM102", # Use a single if statement instead of nested if statements
-    "SIM103", # Return the condition {condition} directly
-    "SIM108", # Use ternary operator {contents} instead of if-else-block
-    "SIM115", # Use context handler for opening files
-    "TRY003", # Avoid specifying long messages outside the exception class
-    "TRY400", # Use `logging.exception` instead of `logging.error`
+  "PLC1901", # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
+  "PLR0911", # Too many return statements ({returns} > {max_returns})
+  "PLR0912", # Too many branches ({branches} > {max_branches})
+  "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+  "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
+  "PLW0108", # Unnecessary lambda wrapping a function call; can often be replaced by the function itself
+  "PLW1641", # __eq__ without __hash__
+  "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+  "PT011",   # pytest.raises({exception}) is too broad, set the `match` parameter or use a more specific exception
+  "PT018",   # Assertion should be broken down into multiple parts
+  "RUF001",  # String contains ambiguous unicode character.
+  "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
+  "RUF015",  # Prefer next(...) over single element slice
+  "RUF043",  # Pattern passed to match= contains metacharacters but is neither escaped nor raw
+  "SIM102",  # Use a single if statement instead of nested if statements
+  "SIM103",  # Return the condition {condition} directly
+  "SIM108",  # Use ternary operator {contents} instead of if-else-block
+  "SIM115",  # Use context handler for opening files
 
-    # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    "W191",
-    "E111",
-    "E114",
-    "E117",
-    "D206",
-    "D300",
-    "Q",
-    "COM812",
-    "COM819",
-    "ISC001",
+  # Moving imports into type-checking blocks can mess with pytest.patch()
+  "TC001", # Move application import {} into a type-checking block
+  "TC002", # Move third-party import {} into a type-checking block
+  "TC003", # Move standard library import {} into a type-checking block
+  # Quotes for typing.cast generally not necessary, only for performance critical paths
+  "TC006", # Add quotes to type expression in typing.cast()
 
-    # Disabled because ruff does not understand type of __all__ generated by a function
-    "PLE0605"
+  "TRY003", # Avoid specifying long messages outside the exception class
+  "TRY400", # Use `logging.exception` instead of `logging.error`
+
+  "UP047", # Non PEP 696 generic function
+  "UP049", # Avoid private type parameter names
+
+  # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191",
+  "E111",
+  "E114",
+  "E117",
+  "D206",
+  "D300",
+  "Q",
+  "COM812",
+  "COM819",
+
+  # Disabled because ruff does not understand type of __all__ generated by a function
+  "PLE0605",
+
+  "FURB116",
 ]
 
 [lint.flake8-pytest-style]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Parameters:
 - **version** - (optional) Defaults to `1`. If set to `2` the API will return fields that were not part of the Dark Sky API.
 - **icon** - (optional) Defaults to `darksky`. If set to `pirate` the API will return icons which aren't apart of the default Dark Sky icon set.
 - **extraVars** - (optional) Is used to add additional parameters to the API response. The only extra parameter at the moment is `stationPressure` but more may be added in the future.
-- **include** - (optional) Is used to add additional data blocks to the API response. The only accepted parameter at the moment is `day_night_forecast` but `aqi` may be added in the future.
+- **include** - (optional) Is used to add additional data blocks to the API response. The accepted parameters at the moment are `day_night_forecast` and `airqualitydetails`.
 - **callback** - (optional) Pass a function to be used as a callback. If used, load_forecast() will use an asynchronous HTTP call and **will not return the forecast object directly**, instead it will be passed to the callback function. Make sure it can accept it.
 
 ----------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ These methods return a DataBlock. Except ``currently()`` which returns a DataPoi
 The .data attributes for each DataBlock is a list of DataPoint objects. This is where all the good data is :)
 
 ```python
-	for hourlyData in byHour.data:
-		print(hourlyData.temperature)
+for hourlyData in byHour.data:
+    print(hourlyData.temperature)
 ```
 
 ## Advanced
@@ -214,23 +214,23 @@ Returned times eg the time parameter on the currently DataPoint are always in UT
 Typically, would would want to do something like this:
 
 ```python
-  # Amsterdam
-  lat  = 52.370235
-  lng  = 4.903549
-  current_time = datetime(2015, 2, 27, 6, 0, 0)
-  forecast = pirateweather.load_forecast(api_key, lat, lng, time=current_time)
+# Amsterdam
+lat = 52.370235
+lng = 4.903549
+current_time = datetime(2015, 2, 27, 6, 0, 0)
+forecast = pirateweather.load_forecast(api_key, lat, lng, time=current_time)
 ```
 
 Be caerful, things can get confusing when doing something like the below. Given that I'm looking up the weather in Amsterdam (+2) while I'm in Perth, Australia (+8).
 
 ```python
-  # Amsterdam
-  lat  = 52.370235
-  lng  = 4.903549
+# Amsterdam
+lat = 52.370235
+lng = 4.903549
 
-  current_time = datetime.datetime.now()
+current_time = datetime.datetime.now()
 
-  forecast = pirateweather.load_forecast(api_key, lat, lng, time=current_time)
+forecast = pirateweather.load_forecast(api_key, lat, lng, time=current_time)
 ```
 
 The result is actually a request for the weather in the future in Amsterdam (by 6 hours) which isn't supported by the Pirate Weather API.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read(fname):
 
 setup(
     name="python-pirateweather",
-    version="1.3.2",
+    version="1.3.3",
     author="cloneofghosts",
     description=("A thin Python Wrapper for the Pirate Weather API"),
     license="BSD 2-clause",

--- a/tests/test_pirateweather.py
+++ b/tests/test_pirateweather.py
@@ -101,7 +101,12 @@ class EndToEnd(unittest.TestCase):
         """Test querying the API endpoint."""
 
         forecast = pirateweather.load_forecast(
-            self.api_key, self.lat, self.lng, units="us", version=2, include="airqualitydetails"
+            self.api_key,
+            self.lat,
+            self.lng,
+            units="us",
+            version=2,
+            include="airqualitydetails",
         )
         fc_cur = forecast.currently()
 

--- a/tests/test_pirateweather.py
+++ b/tests/test_pirateweather.py
@@ -94,7 +94,24 @@ class EndToEnd(unittest.TestCase):
         fc_cur = forecast.currently()
 
         assert forecast.response.status_code == 200
-        assert fc_cur.fireIndex
+        assert fc_cur.fireIndex is not None
+        assert fc_cur.aqi is not None
+
+    def test_air_quality_extras_data_point(self):
+        """Test querying the API endpoint."""
+
+        forecast = pirateweather.load_forecast(
+            self.api_key, self.lat, self.lng, units="us", version=2, include="airqualitydetails"
+        )
+        fc_cur = forecast.currently()
+
+        assert forecast.response.status_code == 200
+        assert fc_cur.coConcentration is not None
+        assert fc_cur.no2Concentration is not None
+        assert fc_cur.ozoneConcentration is not None
+        assert fc_cur.so2Concentration is not None
+        assert fc_cur.pm10 is not None
+        assert fc_cur.pm25 is not None
 
     def test_extra_vars(self):
         """Test querying the API endpoint."""
@@ -130,13 +147,13 @@ class EndToEnd(unittest.TestCase):
         )
         flags = forecast.flags()
 
-        assert len(flags.sources) == 5
-        assert len(flags.sourceTimes) == 4
-        assert flags.nearestStation == 11.97
+        assert len(flags.sources) > 0
+        assert len(flags.sourceTimes) > 0
+        assert flags.nearestStation != -999
         assert flags.units == "si"
-        assert flags.sourceTimes.get("gfs")
-        assert flags.processTime
-        assert flags.ingestVersion
+        assert flags.sourceTimes.get("gfs") is not None
+        assert flags.processTime is not None
+        assert flags.ingestVersion is not None
         assert flags.nearestCity == "Amsterdam"
         assert flags.nearestCountry == "Netherlands"
         assert flags.nearestSubNational == "North Holland"


### PR DESCRIPTION
Fixes #214 and #213 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `load_forecast` documentation to include support for the `airqualitydetails` data block.

* **Improvements**
  * Expanded validation for air-quality and forecast metadata to ensure additional information is available and correctly reported.

* **Release**
  * Updated the package version to 1.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->